### PR TITLE
fix: bug fix verifying proofs

### DIFF
--- a/miden/src/benches/iter_sha2.rs
+++ b/miden/src/benches/iter_sha2.rs
@@ -1,14 +1,15 @@
-use miden::{Assembler, Program, ProgramInputs, ProofOptions};
-use sha2::{Digest, Sha256};
-use miden_core::{StarkField, ProgramOutputs};
+use miden::{Assembler, Program, ProgramInputs, ProgramOutputs, ProofOptions};
+use miden_core::StarkField;
 use miden_stdlib::StdLibrary;
 use rustbench::Benchmark;
+use sha2::{Digest, Sha256};
 
 pub struct Job {
     num_iter: u32,
     program: Program,
     program_input: ProgramInputs,
     proof_options: ProofOptions,
+    program_outputs: ProgramOutputs,
 }
 
 pub fn new_jobs() -> Vec<<Job as Benchmark>::Spec> {
@@ -54,7 +55,7 @@ impl Benchmark for Job {
         let assembler = Assembler::default()
             .with_library(&StdLibrary::default())
             .expect("failed to load stdlib");
-        
+
         let program = assembler
             .compile(source.as_str())
             .expect("Could not compile source");
@@ -64,11 +65,14 @@ impl Benchmark for Job {
         // default (96 bits of security)
         let proof_options = ProofOptions::with_96_bit_security();
 
+        let program_outputs = ProgramOutputs::new(vec![], vec![]);
+
         Job {
             num_iter,
             program,
             program_input,
             proof_options,
+            program_outputs,
         }
     }
 
@@ -82,14 +86,12 @@ impl Benchmark for Job {
         let proof_options = &self.proof_options;
 
         let (output, proof) = miden::prove(program, program_input, proof_options).expect("results");
-        
-        let stack = output
-            .stack_outputs(8)
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
 
-        (stack, proof)
+        let stack_output = output.stack_outputs(8).to_vec();
+
+        self.program_outputs = output;
+
+        (stack_output, proof)
     }
 
     fn host_compute(&mut self) -> Option<<Self as Benchmark>::ComputeOut> {
@@ -104,39 +106,32 @@ impl Benchmark for Job {
         let mut h_output = Vec::<u64>::new();
 
         for i in 0..=7 {
-            let bytes = u32::from_be_bytes(data[i*4..(i*4)+4].try_into().unwrap());
+            let bytes = u32::from_be_bytes(data[i * 4..(i * 4) + 4].try_into().unwrap());
             h_output.push(bytes.into());
         }
 
         Some(h_output)
     }
 
-    fn verify_proof(&self, output: &Self::ComputeOut, proof: &Self::ProofType) -> bool {
+    fn verify_proof(&self, _output: &Self::ComputeOut, proof: &Self::ProofType) -> bool {
         let program = &self.program;
-        let stack_inputs = self
+        let program_outputs = &self.program_outputs;
+        let program_input_u64 = self
             .program_input
             .stack_init()
             .iter()
             .map(|x| x.as_int())
             .collect::<Vec<u64>>();
 
-        let mut stack = output
-            .iter()
-            .cloned()
-            .rev()
-            .collect::<Vec<_>>();
-        
-        // We need 16 elements in the stack to verify 
-        let mut stack_rest = vec![0u64; 12];
-        stack.append(&mut stack_rest);
-
-        let program_outputs = ProgramOutputs::new(stack, vec![]);
-
         let stark_proof = proof.clone();
 
-        let result =
-            miden_verifier::verify(program.hash(), &stack_inputs, &program_outputs, stark_proof)
-                .map_err(|err| format!("Program failed verification! - {}", err));
+        let result = miden::verify(
+            program.hash(),
+            &program_input_u64,
+            program_outputs,
+            stark_proof,
+        )
+        .map_err(|err| format!("Program failed verification! - {}", err));
 
         match result {
             Ok(_) => true,

--- a/miden/src/main.rs
+++ b/miden/src/main.rs
@@ -1,7 +1,7 @@
 mod benches;
 
-use benches::iter_rescue_prime;
 use benches::iter_blake3;
+use benches::iter_rescue_prime;
 use benches::iter_sha2;
 use rustbench::run_jobs;
 


### PR DESCRIPTION
Verifying did not work, I simply ignored `overflow_addrs: Vec<u64>,` of the outputs and only looked at the `stack`. So the verification failed, but I didn't notice because the assertion wasn't enabled. Now everything should work. 

Did some linting as well and found 2 minor bugs. 