### PR TITLE
Add GPU support for risczero benchmark

### DIFF
--- a/risczero/Cargo.lock
+++ b/risczero/Cargo.lock
@@ -366,6 +366,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +469,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fil-rustacuda"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6313e2871ba9705f4151bb60d96b6f43e7444ed82918ba5fb99fbd448e82c34d"
+dependencies = [
+ "bitflags",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
 ]
 
 [[package]]
@@ -1380,6 +1410,7 @@ source = "git+https://github.com/risc0/risc0.git#6efcb45f652b169921eff66384bfc0f
 dependencies = [
  "anyhow",
  "cc",
+ "fil-rustacuda",
  "glob",
  "log",
  "metal",
@@ -1387,6 +1418,8 @@ dependencies = [
  "rayon",
  "risc0-zkp",
  "risc0-zkvm-platform",
+ "rustacuda_core",
+ "rustacuda_derive",
  "sha2",
  "tracing",
 ]
@@ -1420,6 +1453,7 @@ source = "git+https://github.com/risc0/risc0.git#6efcb45f652b169921eff66384bfc0f
 dependencies = [
  "anyhow",
  "bytemuck",
+ "fil-rustacuda",
  "log",
  "metal",
  "ndarray",
@@ -1428,6 +1462,8 @@ dependencies = [
  "rand_core",
  "rayon",
  "risc0-zeroio",
+ "rustacuda_core",
+ "rustacuda_derive",
  "serde",
  "sha2",
  "tracing",
@@ -1480,6 +1516,23 @@ name = "risczero-benchmark-methods"
 version = "0.1.0"
 dependencies = [
  "risc0-build",
+]
+
+[[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/risczero/Cargo.toml
+++ b/risczero/Cargo.toml
@@ -24,3 +24,7 @@ default-features = false
 version = "1.0.0-rc.2"
 git = "https://github.com/risc0/risc0.git"
 default-features = false
+
+[features]
+cuda = ["risc0-zkvm/cuda"]
+metal = ["risc0-zkvm/metal"]

--- a/risczero/methods/guest/Cargo.lock
+++ b/risczero/methods/guest/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 [[package]]
 name = "risc0-circuit-rv32im"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 dependencies = [
  "anyhow",
  "cc",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "risc0-zeroio"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 dependencies = [
  "bytemuck",
  "impl-trait-for-tuples",
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "risc0-zeroio-derive"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkp"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkvm-platform"
 version = "1.0.0-rc.2"
-source = "git+ssh://git@github.com/risc0/risc0.git#05bba804275b9277a2022ac52496b9cc47336600"
+source = "git+https://github.com/risc0/risc0.git#094ef539ec2e20989704b440f79b9e473c3f44ca"
 
 [[package]]
 name = "risczero-benchmark-methods-guest"

--- a/risczero/methods/guest/src/bin/big_sha2.rs
+++ b/risczero/methods/guest/src/bin/big_sha2.rs
@@ -7,7 +7,7 @@ use risc0_zkvm::sha::Sha;
 risc0_zkvm::entry!(main);
 
 pub fn main() {
-    let hasher = sha::Impl { };
+    let hasher = sha::Impl {};
     let data: &[u8] = env::send_recv(0, &[]);
 
     let hash = hasher.hash_bytes(data);

--- a/risczero/methods/guest/src/bin/iter_sha2.rs
+++ b/risczero/methods/guest/src/bin/iter_sha2.rs
@@ -1,14 +1,14 @@
 #![no_std]
 #![no_main]
 
+use risc0_zkp::core::sha::Digest;
 use risc0_zkvm::guest::{env, sha};
 use risc0_zkvm::sha::Sha;
-use risc0_zkp::core::sha::{Digest};
 
 risc0_zkvm::entry!(main);
 
 pub fn main() {
-    let hasher = sha::Impl { };
+    let hasher = sha::Impl {};
     let data: &[u8] = env::send_recv(0, &[]);
 
     let mut num_iter: u32;
@@ -18,7 +18,7 @@ pub fn main() {
     num_iter = num_iter | ((data[3] as u32) << 24);
 
     let mut hash = &data[4..];
-    for _i in 0 .. num_iter {
+    for _ in 0..num_iter {
         hash = hasher.hash_bytes(hash).as_bytes();
     }
 

--- a/risczero/src/benches/big_sha2.rs
+++ b/risczero/src/benches/big_sha2.rs
@@ -71,7 +71,10 @@ impl Benchmark for Job {
 
         match result {
             Ok(_) => true,
-            Err(err) => { println!("{}", err); false},
+            Err(err) => {
+                println!("{}", err);
+                false
+            }
         }
     }
 }

--- a/risczero/src/benches/iter_sha2.rs
+++ b/risczero/src/benches/iter_sha2.rs
@@ -75,7 +75,10 @@ impl Benchmark for Job {
 
         match result {
             Ok(_) => true,
-            Err(err) => { println!("{}", err); false},
+            Err(err) => {
+                println!("{}", err);
+                false
+            }
         }
     }
 }

--- a/risczero/src/main.rs
+++ b/risczero/src/main.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 mod benches;
 


### PR DESCRIPTION
To enable GPU support, run the benchmark with `-F metal` (for macOS) or `-F cuda` for machines with NVidia gear.
