### PR TITLE
Add automated benchmarking using AWS

### DIFF
--- a/docker-aws/Dockerfile
+++ b/docker-aws/Dockerfile
@@ -1,0 +1,5 @@
+FROM polymorpher/delendum-zk-benchmarking:v0.11-linux-x64
+RUN apt-get install awscli -y
+WORKDIR /
+COPY wrapper.sh /wrapper.sh
+CMD "/wrapper.sh"

--- a/docker-aws/README.md
+++ b/docker-aws/README.md
@@ -1,0 +1,37 @@
+# Benchmarking on AWS
+
+This folder contains scripts for 
+
+1. Building the docker image for automated benchmarking on AWS
+2. Setting up AWS infrastructure and service accounts for benchmarking
+3. Launching a single or a group of benchmarking self-terminating instances
+   
+The benchmarking results are automatically stored in an AWS S3 bucket of your choice, each named with the instance type used.
+
+## Docker images used
+- **v0.11-linux-x64**: Extended from v0.1-linux-x64, with Google Cloud Computing Platform tools installed (gcloud, gsutil).
+- **Local Dockerfile**: Extended from v0.11-linux-x64, with AWS CLI installed.
+
+## Steps
+### Prerequisites
+Make sure you have AWS CLI already [installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) on your computer and terminal. Make sure that you have admin credentials configured.
+
+### Prepare the AWS infrastructure
+1. Run Docker daemon
+2. [Create an AWS S3 bucket on your own](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)
+3. Update the variable `aws_bucket` in `user-data.sh` to your bucket name
+4. Run the script `[init-setup.sh](init-setup.sh)` for the rest of the infrastructure.
+
+### Single instance benchmarking
+
+Edit `[launch-aws.sh](launch-aws.sh)` and change `INSTANCE_TYPE` before you run the script.
+
+### Batch benchmarking
+
+Edit `[launch-aws-batch.sh](launch-aws-batch.sh)` and change `INSTANCE_TYPES` before you run the script.
+
+### Collecting the results
+
+The simplest way is to [go to your bucket](https://s3.console.aws.amazon.com/s3/buckets) and download the results using the browser GUI.
+
+Some example outputs are in [example-output](./example-output) .

--- a/docker-aws/example-output/t3.2xlarge.log
+++ b/docker-aws/example-output/t3.2xlarge.log
@@ -1,0 +1,119 @@
+Start time: 20230506180424
+
+--------------------------------------------------
+Start: Polygon Miden
+--------------------------------------------------
+/zk-benchmarking/miden /zk-benchmarking
+
++ begin job_number:   0 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           1
++ proof_duration:     412.866702ms
++ verify_duration:    526.51µs
++ output_bytes:       64
++ proof_bytes:        66896
++ end job_number:     0
+
++ begin job_number:   1 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           10
++ proof_duration:     3.171399989s
++ verify_duration:    477.52µs
++ output_bytes:       64
++ proof_bytes:        83589
++ end job_number:     1
+
++ begin job_number:   2 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           100
++ proof_duration:     26.766787173s
++ verify_duration:    4.906357ms
++ output_bytes:       64
++ proof_bytes:        101418
++ end job_number:     2
+- jobs:               3
+- done
+
++ begin job_number:   0 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           1
++ proof_duration:     721.088844ms
++ verify_duration:    471.901µs
++ output_bytes:       64
++ proof_bytes:        72580
++ end job_number:     0
+
++ begin job_number:   1 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           10
++ proof_duration:     6.227430149s
++ verify_duration:    505.114µs
++ output_bytes:       64
++ proof_bytes:        89594
++ end job_number:     1
+
++ begin job_number:   2 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           100
++ proof_duration:     56.304393879s
++ verify_duration:    544.934µs
++ output_bytes:       64
++ proof_bytes:        108267
++ end job_number:     2
+- jobs:               3
+- done
+
++ begin job_number:   0 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           1
++ proof_duration:     98.137845ms
++ verify_duration:    2.916412ms
++ output_bytes:       32
++ proof_bytes:        53721
++ end job_number:     0
+
++ begin job_number:   1 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           10
++ proof_duration:     60.265845ms
++ verify_duration:    2.877605ms
++ output_bytes:       32
++ proof_bytes:        52405
++ end job_number:     1
+
++ begin job_number:   2 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           100
++ proof_duration:     98.45752ms
++ verify_duration:    2.943331ms
++ output_bytes:       32
++ proof_bytes:        57330
++ end job_number:     2
+
++ begin job_number:   3 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           1000
++ proof_duration:     721.543877ms
++ verify_duration:    3.1464ms
++ output_bytes:       32
++ proof_bytes:        71531
++ end job_number:     3
+- jobs:               4
+- done
+/zk-benchmarking
+--------------------------------------------------
+Done: Polygon Miden
+--------------------------------------------------
+
+
+--------------------------------------------------
+Start: RISC Zero
+--------------------------------------------------
+/zk-benchmarking/risczero /zk-benchmarking
+/zk-benchmarking
+--------------------------------------------------
+Done: RISC Zero
+--------------------------------------------------
+
+
+End time: 20230506181321

--- a/docker-aws/example-output/t3.xlarge.log
+++ b/docker-aws/example-output/t3.xlarge.log
@@ -1,0 +1,119 @@
+Start time: 20230505215703
+
+--------------------------------------------------
+Start: Polygon Miden
+--------------------------------------------------
+/zk-benchmarking/miden /zk-benchmarking
+
++ begin job_number:   0 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           1
++ proof_duration:     1.168270275s
++ verify_duration:    578.122µs
++ output_bytes:       64
++ proof_bytes:        66955
++ end job_number:     0
+
++ begin job_number:   1 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           10
++ proof_duration:     6.932421228s
++ verify_duration:    505.172µs
++ output_bytes:       64
++ proof_bytes:        82215
++ end job_number:     1
+
++ begin job_number:   2 iter_blake3
++ job_name:           "iter_blake3"
++ job_size:           100
++ proof_duration:     61.631246782s
++ verify_duration:    540.23µs
++ output_bytes:       64
++ proof_bytes:        100262
++ end job_number:     2
+- jobs:               3
+- done
+
++ begin job_number:   0 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           1
++ proof_duration:     1.663982063s
++ verify_duration:    485.393µs
++ output_bytes:       64
++ proof_bytes:        73948
++ end job_number:     0
+
++ begin job_number:   1 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           10
++ proof_duration:     13.943667561s
++ verify_duration:    520.438µs
++ output_bytes:       64
++ proof_bytes:        89594
++ end job_number:     1
+
++ begin job_number:   2 iter_sha2
++ job_name:           "iter_sha2"
++ job_size:           100
++ proof_duration:     126.567772059s
++ verify_duration:    1.864603ms
++ output_bytes:       64
++ proof_bytes:        108267
++ end job_number:     2
+- jobs:               3
+- done
+
++ begin job_number:   0 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           1
++ proof_duration:     291.890618ms
++ verify_duration:    8.847414ms
++ output_bytes:       32
++ proof_bytes:        53721
++ end job_number:     0
+
++ begin job_number:   1 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           10
++ proof_duration:     277.430619ms
++ verify_duration:    6.984657ms
++ output_bytes:       32
++ proof_bytes:        53197
++ end job_number:     1
+
++ begin job_number:   2 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           100
++ proof_duration:     383.664496ms
++ verify_duration:    3.998698ms
++ output_bytes:       32
++ proof_bytes:        57330
++ end job_number:     2
+
++ begin job_number:   3 iter_rescue_prime
++ job_name:           "iter_rescue_prime"
++ job_size:           1000
++ proof_duration:     2.190030571s
++ verify_duration:    3.397381ms
++ output_bytes:       32
++ proof_bytes:        71531
++ end job_number:     3
+- jobs:               4
+- done
+/zk-benchmarking
+--------------------------------------------------
+Done: Polygon Miden
+--------------------------------------------------
+
+
+--------------------------------------------------
+Start: RISC Zero
+--------------------------------------------------
+/zk-benchmarking/risczero /zk-benchmarking
+/zk-benchmarking
+--------------------------------------------------
+Done: RISC Zero
+--------------------------------------------------
+
+
+End time: 20230505221652

--- a/docker-aws/init-setup.sh
+++ b/docker-aws/init-setup.sh
@@ -1,0 +1,17 @@
+repository_name="zk-benchmarking"
+account_id=$(aws sts get-caller-identity --query "Account" --output text)
+current_region=$(aws configure get region)
+
+# Push local image to ECR
+aws ecr create-repository --repository-name $repository_name
+aws ecr get-login-password | docker login --username AWS --password-stdin $account_id.dkr.ecr.$current_region.amazonaws.com
+docker build -t $account_id.dkr.ecr.$current_region.amazonaws.com/$repository_name .
+docker push $account_id.dkr.ecr.$current_region.amazonaws.com/$repository_name
+
+# Set up instance profile for EC2 instances
+aws iam create-role --role-name benchmark-role --assume-role-policy-document file://trust-policy.json
+aws iam attach-role-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly --role-name benchmark-role
+aws iam attach-role-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess --role-name benchmark-role
+aws iam attach-role-policy --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess --role-name benchmark-role
+aws iam create-instance-profile --instance-profile-name benchmark-profile
+aws iam add-role-to-instance-profile --role-name benchmark-role --instance-profile-name benchmark-profile

--- a/docker-aws/launch-aws-batch.sh
+++ b/docker-aws/launch-aws-batch.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-export INSTANCE_TYPES=(t2.2xlarge)
+export INSTANCE_TYPES=(t2.2xlarge t3.xlarge)
 
 account_id=$(aws sts get-caller-identity --query "Account" --output text)
-image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
 instance_profile_arn="arn:aws:iam::${account_id}:instance-profile/benchmark-profile"
 
 for INSTANCE_TYPE in "${INSTANCE_TYPES[@]}"; do
+  supported_architectures=$(aws ec2 describe-instance-types --instance-types $INSTANCE_TYPE --query "InstanceTypes[0].ProcessorInfo.SupportedArchitectures" --output text)
+  if [[ $supported_architectures == *"x86_64"* ]]; then
+    image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
+  else
+    image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 --query "Parameters[0].Value" --output text)  
+  fi
   aws ec2 run-instances --image-id $image_id --instance-type $INSTANCE_TYPE --user-data file://user-data.sh --iam-instance-profile Arn=$instance_profile_arn
 done

--- a/docker-aws/launch-aws-batch.sh
+++ b/docker-aws/launch-aws-batch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+export INSTANCE_TYPES=(t2.2xlarge)
+
+account_id=$(aws sts get-caller-identity --query "Account" --output text)
+image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
+instance_profile_arn="arn:aws:iam::${account_id}:instance-profile/benchmark-profile"
+
+for INSTANCE_TYPE in "${INSTANCE_TYPES[@]}"; do
+  aws ec2 run-instances --image-id $image_id --instance-type $INSTANCE_TYPE --user-data file://user-data.sh --iam-instance-profile Arn=$instance_profile_arn
+done

--- a/docker-aws/launch-aws.sh
+++ b/docker-aws/launch-aws.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
-export INSTANCE_TYPE=t3.xlarge
+export INSTANCE_TYPE=g5.2xlarge
 
 account_id=$(aws sts get-caller-identity --query "Account" --output text)
-image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
+
+supported_architectures=$(aws ec2 describe-instance-types --instance-types $INSTANCE_TYPE --query "InstanceTypes[0].ProcessorInfo.SupportedArchitectures" --output text)
+if [[ $supported_architectures == *"x86_64"* ]]; then
+	image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
+else
+	image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 --query "Parameters[0].Value" --output text)	
+fi
+
 instance_profile_arn="arn:aws:iam::${account_id}:instance-profile/benchmark-profile"
 
 aws ec2 run-instances --image-id $image_id --instance-type $INSTANCE_TYPE --user-data file://user-data.sh --iam-instance-profile Arn=$instance_profile_arn

--- a/docker-aws/launch-aws.sh
+++ b/docker-aws/launch-aws.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+export INSTANCE_TYPE=t3.xlarge
+
+account_id=$(aws sts get-caller-identity --query "Account" --output text)
+image_id=$(aws ssm get-parameters --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --query "Parameters[0].Value" --output text)
+instance_profile_arn="arn:aws:iam::${account_id}:instance-profile/benchmark-profile"
+
+aws ec2 run-instances --image-id $image_id --instance-type $INSTANCE_TYPE --user-data file://user-data.sh --iam-instance-profile Arn=$instance_profile_arn

--- a/docker-aws/results-parser.py
+++ b/docker-aws/results-parser.py
@@ -1,0 +1,43 @@
+import csv
+import os
+import subprocess
+
+
+BUCKET_NAME = "zk-benchmarking"
+
+
+def main():
+    subprocess.run([
+        "aws", "s3", "cp", "s3://" + BUCKET_NAME "/",
+        "results/", "--recursive"
+    ])
+    with open("output.csv", 'w', newline='') as write_file:
+        writer = csv.writer(write_file)
+        writer.writerow([
+            "Instance type + job name + job size", "Proof duration",
+            "Verify duration", "Output bytes", "Proof bytes"
+        ])
+        for filename in os.listdir(os.path.join(os.getcwd(), "results")):   
+            with open("results/" + filename, 'r') as read_file:
+                lines = read_file.readlines()
+
+                i = 0
+                while i < len(lines):
+                    if lines[i].startswith("+ job_name"):
+                         writer.writerow(getCsvRow(filename[:-4], i, lines))
+                    i += 1
+
+
+def getCsvRow(instance_type, index, file_lines):
+    job_name = file_lines[index].split(':')[1].strip().strip('"')
+    job_size = file_lines[index + 1].split(':')[1].strip()
+    proof_duration = file_lines[index + 2].split(':')[1].strip()
+    verify_duration = file_lines[index + 3].split(':')[1].strip()
+    output_bytes = file_lines[index + 4].split(':')[1].strip()
+    proof_bytes = file_lines[index + 5].split(':')[1].strip()
+    first_col = "{} {} {}".format(instance_type, job_name, job_size)
+    return [first_col, proof_duration, verify_duration, output_bytes, proof_bytes]
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-aws/trust-policy.json
+++ b/docker-aws/trust-policy.json
@@ -1,0 +1,12 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "ec2.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}

--- a/docker-aws/user-data.sh
+++ b/docker-aws/user-data.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+aws_bucket="delendum-zk-benchmark-test" # Update this to your S3 bucket
+
+instance_type=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
+&& curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)
+bench_output_file=${instance_type}.log
+
+yum update -y
+yum install docker -y
+service docker start
+
+account_id=$(aws sts get-caller-identity --query "Account" --output text)
+current_region=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
+&& curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+
+# Login Docker
+aws ecr get-login-password | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${current_region}.amazonaws.com
+
+docker pull ${account_id}.dkr.ecr.${current_region}.amazonaws.com/zk-benchmarking
+docker run -e AWS_BUCKET=$aws_bucket -e BENCH_OUTPUT_FILE=$bench_output_file --name benchmark ${account_id}.dkr.ecr.${current_region}.amazonaws.com/zk-benchmarking
+
+# Terminate current instance
+instance_id=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
+&& curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+aws ec2 terminate-instances --instance-ids $instance_id

--- a/docker-aws/user-data.sh
+++ b/docker-aws/user-data.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-aws_bucket="delendum-zk-benchmark-test" # Update this to your S3 bucket
+aws_bucket="zk-benchmarking" # Update this to your S3 bucket
 
 instance_type=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
 && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type)

--- a/docker-aws/wrapper.sh
+++ b/docker-aws/wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /zk-benchmarking
+git pull
+./all.sh > $BENCH_OUTPUT_FILE
+aws s3 cp $BENCH_OUTPUT_FILE s3://${AWS_BUCKET}


### PR DESCRIPTION
Please follow the steps in README for verification.

The steps are similar to the GCP ones except that AWS requires using ECR (Elastic Container Registry) as the registry.