### PR TITLE
Added barretenberg benchmarks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "barretenberg"]
+	path = barretenberg
+	url = git@github.com:AztecProtocol/barretenberg.git

--- a/docker/Dockerfile-barretenberg
+++ b/docker/Dockerfile-barretenberg
@@ -1,0 +1,9 @@
+FROM polymorpher/delendum-zk-benchmarking:v0.11-barretenberg-linux-x64
+ENV BENCH_OUTPUT_FILE=output.log
+ENV GCP_SERVICE_ACCOUNT_JSON_KEY=''
+ENV GCP_PROJECT=''
+ENV GCP_SERVICE_ACCOUNT=''
+ENV GCP_BUCKET=''
+WORKDIR /
+COPY wrapper-barretenberg.sh /wrapper.sh
+CMD "/wrapper.sh"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Benchmarking on GCP
 
-This folder contains scripts for 
+This folder contains scripts for
 
 1. building the docker images for automated benchmarking on GCP
 2. setting up a GCP project and service accounts for benchmarking
@@ -14,9 +14,11 @@ You can skip this section if you are only interested in running the benchmarking
 
 - **v0.1-linux-x64**: Debian OS preloaded with rust, ssl, git, and standard build tools, and the benchmarking repository. Suitable for testing locally
 - **v0.11-linux-x64**: Extended from v0.1-linux-x64, with Google Cloud Computing Platform tools installed (gcloud, gsutil)
-- **v0.21-linux-x64**: Extended from v0.11-linux-x64, suitable for deployment as a container image under a GCP VM Instance. The instance will automatically pull the latest code from this repository, build all rust dependencies, compile everything, run all benchmarking, logs to a file, and upload the file to a pre-configured bucket in Google Storage. After this is all done, the instance will self-terminate so it doesn't incur any more billing than necessary. 
+- **v0.21-linux-x64**: Extended from v0.11-linux-x64, suitable for deployment as a container image under a GCP VM Instance. The instance will automatically pull the latest code from this repository, build all rust dependencies, compile everything, run all benchmarking apart from barretenberg, logs to a file, and upload the file to a pre-configured bucket in Google Storage. After this is all done, the instance will self-terminate so it doesn't incur any more billing than necessary.
+- **v0.11-barretenberg-linux-x64**: Alpine preloaded with openmp, with Google Cloud Computing Platform tools installed (gcloud, gsutil), binaries and SRS for external benchmarks for barretenberg.
+- **v0.21-barretenberg-linux-x64**: Extended from v0.11-linux-x64, suitable for deployment as a container image under a GCP VM Instance. The instance will automatically run all benchmarking, log to a file, and upload the file to a pre-configured bucket in Google Storage. After this is all done, the instance will self-terminate so it doesn't incur any more billing than necessary.
 
-You can build **v0.21-linux-x64** using `build.sh` in this folder
+You can build **v0.21-linux-x64** and **v0.21-barretenberg-linux-x64** using `build.sh` in this folder
 
 ## Prepare the GCP project
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,2 +1,3 @@
-!/bin/bash
+#!/bin/bash
+docker build . -f ./Dockerfile-barretenberg --platform linux/amd64 -t polymorpher/delendum-zk-benchmarking:v0.21-barretenberg-linux-x64
 docker build . --platform linux/amd64 -t polymorpher/delendum-zk-benchmarking:v0.21-linux-x64

--- a/docker/launch-gcp-barretenberg.sh
+++ b/docker/launch-gcp-barretenberg.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export INSTANCE_NAME=test-instance-1-barretenberg
+export GCP_PROJECT_ID=delendum-zk-benchmark
+export GCP_ZONE=us-west1-c
+export MACHINE_TYPE=e2-highmem-2
+
+gcloud compute instances create-with-container $INSTANCE_NAME --project=$GCP_PROJECT_ID --zone=$GCP_ZONE --machine-type=$MACHINE_TYPE --network-interface=network-tier=PREMIUM,subnet=default --maintenance-policy=MIGRATE --provisioning-model=STANDARD --image=projects/cos-cloud/global/images/cos-stable-101-17162-40-42 --boot-disk-size=10GB --boot-disk-type=pd-balanced --boot-disk-device-name=instance-1 --container-image=polymorpher/delendum-zk-benchmarking:v0.21-barretenberg-linux-x64 --container-restart-policy=always --container-env=BENCH_OUTPUT_FILE=$INSTANCE_NAME.log --container-env-file=.env --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --labels=container-vm=cos-stable-101-17162-40-42

--- a/docker/launch-gcp-batch.sh
+++ b/docker/launch-gcp-batch.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 export INSTANCE_NAME_BASE=test-batch-instance
+export RUST_BENCHMARKS_SUFFIX=rust
+export BARRETENBERG_BENCHMARKS_SUFFIX=barretenberg
 export GCP_PROJECT_ID=delendum-zk-benchmark
 export GCP_ZONE=us-west1-c
 export MACHINE_TYPES=("e2-highmem-2" "e2-standard-4" "e2-highmem-4" "e2-standard-8")
 
 for MACHINE_TYPE in "${MACHINE_TYPES[@]}"; do
-  export INSTANCE_NAME=${INSTANCE_NAME_BASE}-${MACHINE_TYPE}
+  export INSTANCE_NAME=${INSTANCE_NAME_BASE}-${MACHINE_TYPE}-${RUST_BENCHMARKS_SUFFIX}
   gcloud compute instances create-with-container $INSTANCE_NAME --project=$GCP_PROJECT_ID --zone=$GCP_ZONE --machine-type=$MACHINE_TYPE --network-interface=network-tier=PREMIUM,subnet=default --maintenance-policy=MIGRATE --provisioning-model=STANDARD --image=projects/cos-cloud/global/images/cos-stable-101-17162-40-42 --boot-disk-size=25GB --boot-disk-type=pd-balanced --boot-disk-device-name=instance-1 --container-image=polymorpher/delendum-zk-benchmarking:v0.21-linux-x64 --container-restart-policy=always --container-env=BENCH_OUTPUT_FILE=$INSTANCE_NAME.log --container-env-file=.env --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --labels=container-vm=cos-stable-101-17162-40-42
 done
+
+for MACHINE_TYPE in "${MACHINE_TYPES[@]}"; do
+  export INSTANCE_NAME=${INSTANCE_NAME_BASE}-${MACHINE_TYPE}-${BARRETENBERG_BENCHMARKS_SUFFIX}
+  gcloud compute instances create-with-container $INSTANCE_NAME --project=$GCP_PROJECT_ID --zone=$GCP_ZONE --machine-type=$MACHINE_TYPE --network-interface=network-tier=PREMIUM,subnet=default --maintenance-policy=MIGRATE --provisioning-model=STANDARD --image=projects/cos-cloud/global/images/cos-stable-101-17162-40-42 --boot-disk-size=25GB --boot-disk-type=pd-balanced --boot-disk-device-name=instance-1 --container-image=polymorpher/delendum-zk-benchmarking:v0.21-barretenberg-linux-x64 --container-restart-policy=always --container-env=BENCH_OUTPUT_FILE=$INSTANCE_NAME.log --container-env-file=.env --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --labels=container-vm=cos-stable-101-17162-40-42
+d

--- a/docker/v0.11-barretenberg/Dockerfile
+++ b/docker/v0.11-barretenberg/Dockerfile
@@ -1,0 +1,9 @@
+FROM barretenberg/external_benchmarks
+RUN cd /usr/src/barretenberg/cpp/srs_db/ && ./download_ignition.sh 3 && cd ../build
+RUN apk add --update python3 curl which bash
+RUN curl -sSL https://sdk.cloud.google.com | bash
+WORKDIR /usr/src/barretenberg/cpp/build
+COPY benchmark_parser.sh ./benchmark_parser.sh
+RUN chmod +x ./bin/external_bench
+RUN chmod +x ./benchmark_parser.sh
+CMD "/bin/bash"

--- a/docker/v0.11-barretenberg/benchmark_parser.sh
+++ b/docker/v0.11-barretenberg/benchmark_parser.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+CSV_OUTPUT=$(mktemp)
+sha256_proof_1_iteration_name="generate_sha256_proof_bench/0"
+sha256_proof_10_iterations_name="generate_sha256_proof_bench/1"
+sha256_proof_100_iterations_name="generate_sha256_proof_bench/2"
+sha256_verification_1_iteration_name="verify_sha256_proof_bench/0"
+sha256_verification_10_iterations_name="verify_sha256_proof_bench/1"
+sha256_verification_100_iterations_name="verify_sha256_proof_bench/2"
+blake3s_proof_1_iteration_name="generate_blake3s_proof_bench/0"
+blake3s_proof_10_iterations_name="generate_blake3s_proof_bench/1"
+blake3s_proof_100_iterations_name="generate_blake3s_proof_bench/2"
+blake3s_verification_1_iteration_name="verify_blake3s_proof_bench/0"
+blake3s_verification_10_iterations_name="verify_blake3s_proof_bench/1"
+blake3s_verification_100_iterations_name="verify_blake3s_proof_bench/2"
+
+# Proof size for no public inputs is always 2144, you can check by running the benchmarks with info uncommented
+# Unfortunately, google benchmarks don't allow putting additional info into the output of the benchmark
+proof_size=2144
+
+get_time_measurement() {
+    local test_name="$1"
+    local measurement=$(cat "$CSV_OUTPUT" | grep "$test_name" | cut -d , -f3)
+    local unit_of_measurement=$(cat "$CSV_OUTPUT" | grep "$test_name" | cut -d , -f5)
+    echo "${measurement}${unit_of_measurement}"
+}
+
+./bin/external_bench --benchmark_format=csv >$CSV_OUTPUT
+
+START_TIME=$(date +"%Y%m%d%H%M%S")
+echo "Start time: $START_TIME"
+echo ""
+echo "--------------------------------------------------"
+echo "Start: Barretenberg"
+echo "--------------------------------------------------"
+echo $(pwd)
+echo ""
+echo "+ begin job_number:   0 iter_blake3"
+echo "+ job_name:           \"iter_blake3\""
+echo "+ job_size:           1"
+echo "+ proof_duration:     $(get_time_measurement $blake3s_proof_1_iteration_name)"
+echo "+ verify_duration:    $(get_time_measurement $blake3s_verification_1_iteration_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     0"
+echo ""
+
+echo "+ begin job_number:   1 iter_blake3"
+echo "+ job_name:           \"iter_blake3\""
+echo "+ job_size:           10"
+echo "+ proof_duration:     $(get_time_measurement $blake3s_proof_10_iterations_name)"
+echo "+ verify_duration:    $(get_time_measurement $blake3s_verification_10_iterations_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     1"
+echo ""
+
+echo "+ begin job_number:   2 iter_blake3"
+echo "+ job_name:           \"iter_blake3\""
+echo "+ job_size:           100"
+echo "+ proof_duration:     $(get_time_measurement $blake3s_proof_100_iterations_name)"
+echo "+ verify_duration:    $(get_time_measurement $blake3s_verification_100_iterations_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     2"
+echo "-jobs:                3"
+echo "-done"
+echo ""
+echo "+ begin job_number:   0 iter_sha2"
+echo "+ job_name:           \"iter_sha2\""
+echo "+ job_size:           1"
+echo "+ proof_duration:     $(get_time_measurement $sha256_proof_1_iteration_name)"
+echo "+ verify_duration:    $(get_time_measurement $sha256_verification_1_iteration_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     0"
+echo ""
+
+echo "+ begin job_number:   1 iter_sha2"
+echo "+ job_name:           \"iter_sha2\""
+echo "+ job_size:           10"
+echo "+ proof_duration:     $(get_time_measurement $sha256_proof_10_iterations_name)"
+echo "+ verify_duration:    $(get_time_measurement $sha256_verification_10_iterations_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     1"
+echo ""
+
+echo "+ begin job_number:   2 iter_sha2"
+echo "+ job_name:           \"iter_sha2\""
+echo "+ job_size:           100"
+echo "+ proof_duration:     $(get_time_measurement $sha256_proof_100_iterations_name)"
+echo "+ verify_duration:    $(get_time_measurement $sha256_verification_100_iterations_name)"
+echo "+ proof_bytes:        $proof_size"
+echo "+ end job_number:     2"
+echo "-jobs:                3"
+echo "-done"
+
+# Using almost the same format as standard benchmarks, but we have milliseconds
+echo "--------------------------------------------------"
+echo "Done: Barretenberg"
+echo "--------------------------------------------------"

--- a/docker/v0.11-barretenberg/build.sh
+++ b/docker/v0.11-barretenberg/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../../barretenberg/cpp/
+docker build -f dockerfiles/Dockerfile.x86_64-linux-clang-benchmarks . --platform linux/amd64 -t barretenberg/external_benchmarks
+cd ../../docker/v0.11-barretenberg
+docker build . --platform linux/amd64 -t polymorpher/delendum-zk-benchmarking:v0.11-barretenberg-linux-x64

--- a/docker/wrapper-barretenberg.sh
+++ b/docker/wrapper-barretenberg.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+./benchmark_parser.sh >$BENCH_OUTPUT_FILE
+echo $GCP_SERVICE_ACCOUNT_JSON_KEY >/gcp_cred.json
+gcloud auth activate-service-account --key-file /gcp_cred.json
+gsutil cp $BENCH_OUTPUT_FILE gs://${GCP_BUCKET}
+export NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
+export ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
+gcloud --quiet compute instances delete $NAME --zone=$ZONE


### PR DESCRIPTION
Hi Delendum Team!
We'd love to have barretenberg join your benchmark. This pull requests aims to add barretenberg Ultraplonk benchmark for sha2 and blake3s. Unfortunately, there were some issues that didn't allow me to add it to the standard delendum container for benchmarking, so the benchmarks are separate. Specifically, barretenberg relies on openmp and is built in alpine, which makes it very hard to add compiled binaries to rust crates.
Please tell me if there are any changes you'd like me to make so that it's easier to run or organize.